### PR TITLE
Use a node-based proxy instead of browsermob-proxy

### DIFF
--- a/lib/browser-emulator.js
+++ b/lib/browser-emulator.js
@@ -19,6 +19,7 @@ var Browser = function(config) {
     var self = this;
     var flow = webdriver.promise.controlFlow();
     var driverPromise = new webdriver.promise.Deferred();
+    var closed = false;
 
     function init() {
         config = config || {};
@@ -101,7 +102,6 @@ var Browser = function(config) {
                                 pendingNetworkDataGathering = 0;
                             }
                             pendingNetworkDataGathering++;
-                            serverResponse.endTime = new Date();
                             l(req, serverResponse, responseDone);
                         });
                     });
@@ -203,7 +203,7 @@ var Browser = function(config) {
                     });
                 }
                 self.emit('error', err);
-                self.close();
+                closeBrowser(d);
             }
         );
     }
@@ -259,6 +259,23 @@ var Browser = function(config) {
         });
     }
 
+    this.abort = function() {
+        return driverPromise.then(closeBrowser);
+    }
+
+    function closeBrowser(d, processToKill) {
+        if (closed) {
+            return new webdriver.promise.Deferred().fulfill();
+        }
+        return d.close().then(d.quit.bind(d)).then(chromeservice.stop.bind(chromeservice)).then(function() {
+            closed = true;
+            rimraf(uadir, function () {});
+            if (processToKill) {
+                processToKill.kill();
+            }
+        });
+    }
+
     this.close = function(processToKill) {
         var networkdone = new webdriver.promise.Deferred();
         if (self.network) {
@@ -271,10 +288,7 @@ var Browser = function(config) {
         }
         return self.do(function(d) {
             self.network.stop();
-            return networkdone.then(d.close.bind(d)).then(d.quit.bind(d)).then(chromeservice.stop.bind(chromeservice)).then(function() {
-                rimraf(uadir, function () {});
-                processToKill.kill();
-            });
+            return networkdone.then(function() { closeBrowser(d, processToKill);});
         });
     };
 

--- a/lib/browser-emulator.js
+++ b/lib/browser-emulator.js
@@ -48,24 +48,41 @@ var Browser = function(config) {
             var proxy = new ThinProxy({strictSSL:true});
             var pendingNetworkDataGathering = null;
 
+            var responseListeners = [];
+            var requestListeners = [];
+
             self.on('newListener', function(eventName, listener) {
-                if (eventName === "request" || eventName === "response") {
-                    proxy.use(function(req, res, next) {
-                        listener(req, res);
-                        next();
-                    });
+                if (eventName === "request") {
+                    requestListeners.push(listener);
+                } else if (eventName === "response") {
+                    responseListeners.push(listener);
                 }
             });
+
+            function networkAnalysisDone() {
+                pendingNetworkDataGathering--;
+            }
+
+            proxy.use(function(req, res, next) {
+                requestListeners.forEach(function (l) {
+                    l(req, res, networkAnalysisDone);
+                });
+                proxy.forward(req, res, function (proxyReq) {
+                    proxyReq.on('response', function (serverResponse) {
+                        responseListeners.forEach(function (l) {
+                            l(req, serverResponse, networkAnalysisDone);
+                        });
+                    });
+                });
+                next();
+            });
+
 
             proxy.on("request", function() {
                 if (pendingNetworkDataGathering === null) {
                     pendingNetworkDataGathering = 0;
                 }
                 pendingNetworkDataGathering++;
-            });
-
-            proxy.on("response", function() {
-                pendingNetworkDataGathering--;
             });
 
             proxy.on("error", function(err) {
@@ -221,16 +238,19 @@ var Browser = function(config) {
     }
 
     this.close = function(processToKill) {
-        return self.do(function(d) {
+        var networkdone = new webdriver.promise.Deferred();
+        if (self.network) {
             self.network.on("done", function() {
                 self.emit('done');
+                networkdone.fulfill();
             });
 
-            if (self.network) {
-                self.network.stop();
-            }
-
-            return d.close().then(d.quit.bind(d)).then(chromeservice.stop.bind(chromeservice)).then(function() {
+            self.network.stop();
+        } else {
+            networkdone.fulfill();
+        }
+        return self.do(function(d) {
+            return networkdone.then(d.close.bind(d)).then(d.quit.bind(d)).then(chromeservice.stop.bind(chromeservice)).then(function() {
                 rimraf(uadir, function () {});
                 processToKill.kill();
             });

--- a/lib/browser-emulator.js
+++ b/lib/browser-emulator.js
@@ -8,9 +8,12 @@ var uuid = require('node-uuid');
 var rimraf = require('rimraf');
 
 var Browser = function(config) {
-    var display, uaHeader, trackNetwork, browsermobProxy, proxy, driver,
-    tmpdir, uadir;
+    var display, uaHeader, trackNetwork, proxy, driver,
+        tmpdir, uadir, proxyPort;
     var chromeservice;
+    var display, uaHeader, trackNetwork, proxy, driver,
+    tmpdir, uadir, proxyPort;
+
     var networkDataGatheringDone = function() {};
     var pendingNetworkDataGathering = 0;
     var self = this;
@@ -25,38 +28,65 @@ var Browser = function(config) {
         self.height = config.browserHeight || 480;
         self.desktopWidth = config.browserDekstopWidth || self.width * 3;
         self.desktopHeight = config.browserDekstopHeight || self.height * 3;
+        self.network = null;
+        proxyPort = config.proxyPort || 8128;
         display = config.displayServer || 0;
         uaHeader = config.uaHeader || "";
         tmpdir = config.tmpdir || "/tmp";
         uadir = tmpdir + "/mobile-checker-" + uuid.v4();
         trackNetwork = config.trackNetwork || false;
-        browsermobProxy = config.browsermobProxy || {
-            'host': 'localhost',
-            'port': 8080
-        };
+        if (trackNetwork) {
+            setupProxy();
+        }
+
     }
 
     function setupProxy() {
-        var Proxy = require('browsermob-proxy').Proxy;
-        proxy = new Proxy({
-            port: browsermobProxy.port,
-            host: browsermobProxy.host
-        });
+        var NetworkInterceptor = function () {
+            var self = this;
+            var ThinProxy = require('thin');
+            var proxy = new ThinProxy({strictSSL:true});
+
+            self.on('newListener', function(eventName, listener) {
+                if (eventName === "request" || eventName === "response") {
+                    proxy.use(function(req, res, next) {
+                        listener(req, res);
+                        next();
+                    });
+                }
+            });
+
+            proxy.on("error", function(err) {
+                console.log(err);
+                self.emit("error", err);
+            });
+
+            proxy.listen(proxyPort, '0.0.0.0', function(err) {
+                self.emit("proxyError", err);
+            });
+
+            self.stop = function() {
+                self.emit("done");
+                proxy.close();
+            };
+        };
+
+        util.inherits(NetworkInterceptor, EventEmitter);
+
+        self.network = new NetworkInterceptor();
     }
 
-    function setupBrowser(proxyAddr) {
+    function setupBrowser() {
         var chromedriver = require("chromedriver");
         var chrome = require("selenium-webdriver/chrome");
         var proxy = require('selenium-webdriver/proxy');
         var capabilities = webdriver.Capabilities.chrome();
 
-        if (proxyAddr) {
-            var proxyPrefs = proxy.manual({
-                http: proxyAddr,
-                https: proxyAddr
-            });
-            capabilities.set(webdriver.Capability.PROXY, proxyPrefs);
-        }
+        var proxyPrefs = proxy.manual({
+            http: '0.0.0.0:' + proxyPort,
+            https: '0.0.0.0:'+proxyPort
+        });
+        capabilities.set(webdriver.Capability.PROXY, proxyPrefs);
 
         // enabling metaviewport
         var options = new chrome.Options();
@@ -91,35 +121,6 @@ var Browser = function(config) {
         });
     }
 
-    function reportNetworkTraffic(err, har) {
-        var data;
-        if (err) {
-            self.emit('error', new Error(
-                "Failed gathering network traffic: " + err));
-            return;
-        }
-        try {
-            data = JSON.parse(har);
-        } catch (e) {
-            self.emit('error', new Error(
-                "Failed to parse network traffic data from proxy"));
-            return;
-        }
-        pendingNetworkDataGathering = EventEmitter.listenerCount(self, 'har');
-
-        self.emit('har', data, finishNetworkTrafficReport);
-        if (pendingNetworkDataGathering === 0) {
-            self.emit('networkdone');
-        }
-    }
-
-    function finishNetworkTrafficReport() {
-        pendingNetworkDataGathering--;
-        if (pendingNetworkDataGathering === 0) {
-            self.emit('networkdone');
-            pendingNetworkDataGathering = null;
-        }
-    }
 
     // dontGiveUp from https://gist.github.com/domenic/2936696
     // we need to protect any code sent to the drivder
@@ -202,44 +203,19 @@ var Browser = function(config) {
 
     this.close = function(processToKill) {
         return self.do(function(d) {
-            var p = new webdriver.promise.Promise(function(res, rej) {
-                networkDataGatheringDone();
-                self.on('networkdone', res);
-            }).then(function() {
-                self.emit('done');
-                return d.close().then(d.quit.bind(d)).then(chromeservice.stop.bind(chromeservice)).then(function() {
-                    rimraf(uadir, function () {});
-                    processToKill.kill();
-                });
+            if (self.network) {
+                self.network.stop();
+            }
+            return d.close().then(d.quit.bind(d)).then(chromeservice.stop.bind(chromeservice)).then(function() {
+                rimraf(uadir, function () {});
+                processToKill.kill();
             });
-            return p;
         });
     };
 
     this.open = function(url) {
-        if (trackNetwork) {
-            setupProxy();
-            var setupProxyAndGet = function() {
-                return function(proxyAddr, done) {
-                    setupBrowser(proxyAddr);
-                    networkDataGatheringDone = done;
-                    flow.execute(function() {
-                        get(url);
-                    });
-                };
-            };
-            flow.execute(function() {
-                proxy.cbHAR({
-                    name: url,
-                    captureHeaders: true,
-                    captureContent: true,
-                    captureBinaryContent: true
-                }, setupProxyAndGet(), reportNetworkTraffic);
-            });
-        } else {
-            setupBrowser();
-            return get(url);
-        }
+        setupBrowser();
+        return get(url);
     };
 
     this.do = function(fn) {
@@ -263,7 +239,6 @@ var Browser = function(config) {
                         if (err) {
                             self.emit('error', err);
                         } else {
-                            console.log(path);
                             // resize the screenshot
                             easyimg.resize({
                                 src: path,

--- a/lib/browser-emulator.js
+++ b/lib/browser-emulator.js
@@ -13,7 +13,7 @@ var Browser = function(config) {
     var chromeservice;
     var display, uaHeader, trackNetwork, proxy, driver,
     tmpdir, uadir, proxyPort;
-
+    var pendingTasks = null;
     var networkDataGatheringDone = function() {};
     var pendingNetworkDataGathering = 0;
     var self = this;
@@ -280,16 +280,26 @@ var Browser = function(config) {
         var networkdone = new webdriver.promise.Deferred();
         if (self.network) {
             self.network.on("processingdone", function() {
-                self.emit('done');
                 networkdone.fulfill();
             });
         } else {
             networkdone.fulfill();
         }
+        var tasksdone = new webdriver.promise.Deferred();
+        self.on("tasksdone", function() {
+            tasksdone.fulfill();
+        });
+        if (pendingTasks === null) {
+            self.emit("tasksdone");
+        }
         return self.do(function(d) {
             self.network.stop();
-            return networkdone.then(function() { closeBrowser(d, processToKill);});
-        });
+            return networkdone.then(function () { return tasksdone;})
+                .then(function() {
+                    self.emit('done');
+                    return closeBrowser(d, processToKill);
+                });
+        }, true);
     };
 
     this.open = function(url) {
@@ -297,13 +307,25 @@ var Browser = function(config) {
         return get(url);
     };
 
-    this.do = function(fn) {
+    function taskDone() {
+        pendingTasks--;
+        if (pendingTasks === 0) {
+            self.emit("tasksdone");
+        }
+    }
+
+    this.do = function(fn, nowait) {
+        if (!nowait) {
+            pendingTasks = pendingTasks || 0;
+            pendingTasks++;
+
+        }
         return driverPromise.then(function(d) {
             return dontGiveUpOnModal(function() {
                 return flow.execute(
                     function() {
-                        fn(d);
-                    });
+                        return fn(d, taskDone);
+                    })
             }, d);
         });
     };
@@ -334,7 +356,7 @@ var Browser = function(config) {
                                 });
                         }
                     });
-            });
+            }, true);
         });
     };
 

--- a/lib/browser-emulator.js
+++ b/lib/browser-emulator.js
@@ -46,6 +46,7 @@ var Browser = function(config) {
             var self = this;
             var ThinProxy = require('thin');
             var proxy = new ThinProxy({strictSSL:true});
+            var pendingNetworkDataGathering = null;
 
             self.on('newListener', function(eventName, listener) {
                 if (eventName === "request" || eventName === "response") {
@@ -54,6 +55,17 @@ var Browser = function(config) {
                         next();
                     });
                 }
+            });
+
+            proxy.on("request", function() {
+                if (pendingNetworkDataGathering === null) {
+                    pendingNetworkDataGathering = 0;
+                }
+                pendingNetworkDataGathering++;
+            });
+
+            proxy.on("response", function() {
+                pendingNetworkDataGathering--;
             });
 
             proxy.on("error", function(err) {
@@ -66,8 +78,15 @@ var Browser = function(config) {
             });
 
             self.stop = function() {
-                self.emit("done");
-                proxy.close();
+                if (pendingNetworkDataGathering === 0) {
+                    self.emit('done');
+                    proxy.close();
+                } else {
+                    setTimeout(function () {
+                        proxy.close();
+                        self.emit('done');
+                    }, 1000);
+                }
             };
         };
 
@@ -203,9 +222,14 @@ var Browser = function(config) {
 
     this.close = function(processToKill) {
         return self.do(function(d) {
+            self.network.on("done", function() {
+                self.emit('done');
+            });
+
             if (self.network) {
                 self.network.stop();
             }
+
             return d.close().then(d.quit.bind(d)).then(chromeservice.stop.bind(chromeservice)).then(function() {
                 rimraf(uadir, function () {});
                 processToKill.kill();

--- a/lib/browser-emulator.js
+++ b/lib/browser-emulator.js
@@ -6,6 +6,7 @@ var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 var uuid = require('node-uuid');
 var rimraf = require('rimraf');
+var domain = require('domain');
 
 var Browser = function(config) {
     var display, uaHeader, trackNetwork, proxy, driver,
@@ -20,6 +21,13 @@ var Browser = function(config) {
     var flow = webdriver.promise.controlFlow();
     var driverPromise = new webdriver.promise.Deferred();
     var closed = false;
+    var d = domain.create();
+    d.on('error', function(err) {
+        console.error(err);
+        if (err) {
+            console.log(err.stack);
+        }
+    });
 
     function init() {
         config = config || {};
@@ -39,7 +47,7 @@ var Browser = function(config) {
         if (trackNetwork) {
             setupProxy();
         }
-
+        d.add(this);
     }
 
     function setupProxy() {
@@ -50,10 +58,13 @@ var Browser = function(config) {
             var pendingNetworkDataGathering = null;
             var pendingNetworkDataProcessing = 0;
             var loaded = false;
+            var closed = false;
 
             var responseListeners = [];
             var requestListeners = [];
             var doneListeners = [];
+
+            d.add(proxy);
 
             self.on('newListener', function(eventName, listener) {
                 if (eventName === "request") {
@@ -70,33 +81,49 @@ var Browser = function(config) {
                 networkGatheringDone();
             }
 
+            function finishNetworkGathering() {
+                if (closed) {
+                    return;
+                }
+                closed = true;
+                proxy.close(function (err) {
+                    if (err) {
+                        console.log(err.stack);
+                    }
+                });
+                if (pendingNetworkDataGathering === null || doneListeners.length === 0) {
+                    self.emit('processingdone');
+                    return;
+                }
+                doneListeners.forEach(function(l) {
+                    pendingNetworkDataProcessing = 0;
+                    pendingNetworkDataProcessing++;
+                    l(function () {
+                        pendingNetworkDataProcessing--;
+                        if (pendingNetworkDataProcessing === 0) {
+                            self.emit('processingdone');
+                        }
+                        });
+                });
+            }
+
             function networkGatheringDone() {
                 if ((pendingNetworkDataGathering === 0 || pendingNetworkDataGathering === null)
                     && loaded) {
-                    proxy.close();
-                    if (pendingNetworkDataGathering === null || doneListeners.length === 0) {
-                        self.emit('processingdone');
-                        return;
-                    }
-                    doneListeners.forEach(function(l) {
-                        pendingNetworkDataProcessing = 0;
-                        pendingNetworkDataProcessing++;
-                        l(function () {
-                            pendingNetworkDataProcessing--;
-                            if (pendingNetworkDataProcessing === 0) {
-                                self.emit('processingdone');
-                            }
-                        });
-                    });
+                    finishNetworkGathering();
                 }
             }
 
             proxy.use(function(req, res, next) {
+                d.add(req);
+                d.add(res);
                 requestListeners.forEach(function (l) {
                     l(req, res, networkGatheringDone);
                 });
                 proxy.forward(req, res, function (proxyReq) {
+                    d.add(proxyReq);
                     proxyReq.on('response', function (serverResponse) {
+                        d.add(serverResponse);
                         responseListeners.forEach(function (l) {
                             if (pendingNetworkDataGathering === null) {
                                 pendingNetworkDataGathering = 0;
@@ -116,7 +143,7 @@ var Browser = function(config) {
 
             proxy.on("error", function(err) {
                 console.log(err);
-                self.emit("error", err);
+                self.emit("proxyError", err);
             });
 
             proxy.listen(proxyPort, '0.0.0.0', function(err) {
@@ -126,12 +153,16 @@ var Browser = function(config) {
             self.stop = function() {
                 loaded = true ;
                 networkGatheringDone();
+                // we timeout after 10s
+                setTimeout(finishNetworkGathering, 10000);
+
             };
         };
 
         util.inherits(NetworkInterceptor, EventEmitter);
 
         self.network = new NetworkInterceptor();
+        d.add(self.network);
     }
 
     function setupBrowser() {
@@ -279,9 +310,12 @@ var Browser = function(config) {
     this.close = function(processToKill) {
         var networkdone = new webdriver.promise.Deferred();
         if (self.network) {
-            self.network.on("processingdone", function() {
+            self.network.once("processingdone", function() {
                 networkdone.fulfill();
             });
+            setTimeout(function () {
+                networkdone.fulfill();
+            }, 10000);
         } else {
             networkdone.fulfill();
         }
@@ -318,7 +352,6 @@ var Browser = function(config) {
         if (!nowait) {
             pendingTasks = pendingTasks || 0;
             pendingTasks++;
-
         }
         return driverPromise.then(function(d) {
             return dontGiveUpOnModal(function() {
@@ -331,7 +364,7 @@ var Browser = function(config) {
     };
 
     this.takeScreenshot = function(path) {
-        return self.do(function(d) {
+        return self.do(function screenshot(d) {
             d.takeScreenshot().then(function(data) {
                 var base64Data = data.replace(
                     /^data:image\/png;base64,/, "");
@@ -356,8 +389,8 @@ var Browser = function(config) {
                                 });
                         }
                     });
-            }, true);
-        });
+            });
+        }, true);
     };
 
     init();

--- a/lib/browser-emulator.js
+++ b/lib/browser-emulator.js
@@ -45,7 +45,7 @@ var Browser = function(config) {
         var NetworkInterceptor = function () {
             var self = this;
             var ThinProxy = require('thin');
-            var proxy = new ThinProxy({strictSSL:true});
+            var proxy = new ThinProxy({strictSSL:true, followRedirect: false});
             var pendingNetworkDataGathering = null;
 
             var responseListeners = [];

--- a/lib/browser-emulator.js
+++ b/lib/browser-emulator.js
@@ -202,7 +202,7 @@ var Browser = function(config) {
                         dontGiveUpOnModal(f, d, count - 1);
                     });
                 }
-                self.emit('error', err);
+                self.emit('fatalerror', err);
                 closeBrowser(d);
             }
         );

--- a/lib/browser-emulator.js
+++ b/lib/browser-emulator.js
@@ -47,30 +47,62 @@ var Browser = function(config) {
             var ThinProxy = require('thin');
             var proxy = new ThinProxy({strictSSL:true, followRedirect: false});
             var pendingNetworkDataGathering = null;
+            var pendingNetworkDataProcessing = 0;
+            var loaded = false;
 
             var responseListeners = [];
             var requestListeners = [];
+            var doneListeners = [];
 
             self.on('newListener', function(eventName, listener) {
                 if (eventName === "request") {
                     requestListeners.push(listener);
                 } else if (eventName === "response") {
                     responseListeners.push(listener);
+                } else if (eventName === "done") {
+                    doneListeners.push(listener);
                 }
             });
 
-            function networkAnalysisDone() {
+            function responseDone() {
                 pendingNetworkDataGathering--;
+                networkGatheringDone();
+            }
+
+            function networkGatheringDone() {
+                if ((pendingNetworkDataGathering === 0 || pendingNetworkDataGathering === null)
+                    && loaded) {
+                    proxy.close();
+                    if (pendingNetworkDataGathering === null || doneListeners.length === 0) {
+                        self.emit('processingdone');
+                        return;
+                    }
+                    doneListeners.forEach(function(l) {
+                        pendingNetworkDataProcessing = 0;
+                        pendingNetworkDataProcessing++;
+                        l(function () {
+                            pendingNetworkDataProcessing--;
+                            if (pendingNetworkDataProcessing === 0) {
+                                self.emit('processingdone');
+                            }
+                        });
+                    });
+                }
             }
 
             proxy.use(function(req, res, next) {
                 requestListeners.forEach(function (l) {
-                    l(req, res, networkAnalysisDone);
+                    l(req, res, networkGatheringDone);
                 });
                 proxy.forward(req, res, function (proxyReq) {
                     proxyReq.on('response', function (serverResponse) {
                         responseListeners.forEach(function (l) {
-                            l(req, serverResponse, networkAnalysisDone);
+                            if (pendingNetworkDataGathering === null) {
+                                pendingNetworkDataGathering = 0;
+                            }
+                            pendingNetworkDataGathering++;
+                            serverResponse.endTime = new Date();
+                            l(req, serverResponse, responseDone);
                         });
                     });
                 });
@@ -78,11 +110,8 @@ var Browser = function(config) {
             });
 
 
-            proxy.on("request", function() {
-                if (pendingNetworkDataGathering === null) {
-                    pendingNetworkDataGathering = 0;
-                }
-                pendingNetworkDataGathering++;
+            proxy.on("request", function(req) {
+                req.startTime = new Date();
             });
 
             proxy.on("error", function(err) {
@@ -95,15 +124,8 @@ var Browser = function(config) {
             });
 
             self.stop = function() {
-                if (pendingNetworkDataGathering === 0) {
-                    self.emit('done');
-                    proxy.close();
-                } else {
-                    setTimeout(function () {
-                        proxy.close();
-                        self.emit('done');
-                    }, 1000);
-                }
+                loaded = true ;
+                networkGatheringDone();
             };
         };
 
@@ -240,16 +262,15 @@ var Browser = function(config) {
     this.close = function(processToKill) {
         var networkdone = new webdriver.promise.Deferred();
         if (self.network) {
-            self.network.on("done", function() {
+            self.network.on("processingdone", function() {
                 self.emit('done');
                 networkdone.fulfill();
             });
-
-            self.network.stop();
         } else {
             networkdone.fulfill();
         }
         return self.do(function(d) {
+            self.network.stop();
             return networkdone.then(d.close.bind(d)).then(d.quit.bind(d)).then(chromeservice.stop.bind(chromeservice)).then(function() {
                 rimraf(uadir, function () {});
                 processToKill.kill();

--- a/package.json
+++ b/package.json
@@ -10,14 +10,15 @@
         "url": "https://github.com/w3c/mobile-web-browser-emulator/issues"
     },
     "dependencies": {
-        "browsermob-proxy":"1.0.6",
+        "headless": "0.2.1",
+        "selenium-webdriver": "^2.46.1",
         "chromedriver": "^2.15",
+	"thin":"0.1.3",
         "easyimage": "1.0.2",
         "headless": "0.2.1",
         "intl": "^0.1.4",
         "media-type": "0.1.0",
         "metaviewport-parser": "^0.0.1",
-        "selenium-webdriver": "^2.46.1",
         "node-uuid": "1.4.3",
         "rimraf": "^2.4.0"
     },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "headless": "0.2.1",
         "selenium-webdriver": "^2.46.1",
         "chromedriver": "^2.15",
-	"thin":"0.1.3",
+	"thin":"^0.3.0",
         "easyimage": "1.0.2",
         "headless": "0.2.1",
         "intl": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mobile-web-browser-emulator",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "license": "MIT",
     "repository": {
         "type": "git",
@@ -29,6 +29,6 @@
     },
     "scripts": {
        "start": "node app.js",
-       "test": "mocha --timeout 10000 --globals ErrorHandler"
+       "test": "mocha --timeout 10000 --globals ErrorHandler,domain"
     }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "headless": "0.2.1",
         "selenium-webdriver": "^2.46.1",
         "chromedriver": "^2.15",
-	"thin":"^0.3.0",
+	"thin":"^0.3.1",
         "easyimage": "1.0.2",
         "headless": "0.2.1",
         "intl": "^0.1.4",

--- a/test/browser-emulator-tests.js
+++ b/test/browser-emulator-tests.js
@@ -12,7 +12,7 @@ describe("Starting and quiting browser", function() {
     it('should start and stop without error with correct proxy', function(
         done) {
         var browser = new Browser({
-            port: 8080,
+            proxyPort: 8000,
             trackNetwork: true
         });
         browser.on('error', function(msg) {
@@ -23,41 +23,22 @@ describe("Starting and quiting browser", function() {
         browser.close().then(done);
     });
 
-    it('should emit an error with incorrect proxy', function(done) {
-        var browser = new Browser({
-            browsermobProxy: {
-                port: 8081
-            },
-            trackNetwork: true
-        });
-        browser.on('error', function(err) {
-            expect(err.message).to.be(
-                'Failed gathering network traffic: Error: connect ECONNREFUSED'
-            );
-            done();
-        });
-        browser.open("file://" + __dirname + "/browser-tests/ok.html");
-        browser.close();
-    });
-
 });
 
 describe("Getting data from network", function() {
-    var server = require("./test_server/test_app.js");
-    var browser = new Browser({
-        browsermobProxy: {
-            port: 8080
-        },
-        trackNetwork: true
-    });
-
+    var server, browser;
     before(function() {
+        server = require("./test_server/test_app.js");
+        browser = new Browser({
+            proxyPort: 8081,
+            trackNetwork: true
+        });
         server.start(3001, '/../browser-tests');
     });
 
     it("should get the status code of a loadable page", function(done) {
-        browser.on('har', function(har) {
-            expect(har.log.entries[0].response.status).to.be(200);
+        browser.network.on('response', function(req, res) {
+            expect(res.statusCode).to.be(200);
         });
         browser.open("http://localhost:3001/ok.html");
         browser.close().then(done);
@@ -69,21 +50,21 @@ describe("Getting data from network", function() {
 });
 
 describe("Getting data from browser and network", function() {
-    var server = require("./test_server/test_app.js");
-    var browser = new Browser({
-        browsermobProxy: {
-            port: 8080
-        },
-        trackNetwork: true
-    });
+    var server, browser;
+
     before(function() {
+        server = require("./test_server/test_app.js");
+        browser = new Browser({
+            proxyPort: 8082,
+            trackNetwork: true
+        });
         server.start(3001, '/../browser-tests');
     });
 
     it("should get the status code and title of a loadable page", function(
         done) {
-        browser.on('har', function(har) {
-            expect(har.log.entries[0].response.status).to.be(200);
+        browser.network.on('response', function(req, res) {
+            expect(res.statusCode).to.be(200);
         });
 
         browser.open("http://localhost:3001/ok.html");

--- a/test/browser-emulator-tests.js
+++ b/test/browser-emulator-tests.js
@@ -37,8 +37,9 @@ describe("Getting data from network", function() {
     });
 
     it("should get the status code of a loadable page", function(done) {
-        browser.network.on('response', function(req, res) {
+        browser.network.on('response', function(req, res, bdone) {
             expect(res.statusCode).to.be(200);
+            res.on('end', function() { bdone();});
         });
         browser.open("http://localhost:3001/ok.html");
         browser.close().then(done);
@@ -63,17 +64,19 @@ describe("Getting data from browser and network", function() {
 
     it("should get the status code and title of a loadable page", function(
         done) {
-        browser.network.on('response', function(req, res) {
+        browser.network.on('response', function(req, res, bdone) {
             expect(res.statusCode).to.be(200);
+            res.on('end', function() { bdone();});
         });
 
         browser.open("http://localhost:3001/ok.html");
-        browser.do(function(d) {
+        browser.do(function(d, bdone) {
             return d.findElement(browser.webdriver.By.tagName('title')).then(
                 function(title) {
                     title.getInnerHtml().then(function(
                         titleText) {
                         expect(titleText).to.be('OK');
+                        bdone();
                     });
                 });
         });
@@ -91,12 +94,13 @@ describe("Getting data from browser", function() {
         var browser = new Browser();
 
         browser.open("file://" + __dirname + "/browser-tests/ok.html");
-        browser.do(function(driver) {
+        browser.do(function(driver, bdone) {
             return driver.findElement(webdriver.By.tagName('title'))
                 .then(function(title) {
                     title.getInnerHtml().then(function(
                         titleText) {
                         expect(titleText).to.be('OK');
+                        bdone();
                     });
                 });
         });
@@ -112,12 +116,13 @@ describe("Getting data from browser", function() {
             browser.on('alert', function(text) {
                 expect(text).to.be('test');
             });
-            browser.do(function(driver) {
+            browser.do(function(driver, bdone) {
                 return driver.findElement(webdriver.By.tagName('title'))
                     .then(function(title) {
                         title.getInnerHtml().then(function(
                             titleText) {
                             expect(titleText).to.be('Alert');
+                            bdone();
                         });
                     });
             });
@@ -135,13 +140,14 @@ describe("Getting data from browser", function() {
                 browser.close().then(done);
             });
             setTimeout(function() {
-                browser.do(function(driver) {
+                browser.do(function(driver, bdone) {
                     return driver.findElement(webdriver.By.tagName(
                         'title')).then(function(title) {
                         title.getInnerHtml().then(function(
                             titleText) {
                             expect(titleText).to.be(
                                 'Alert2');
+                            bdone();
                         });
                     });
                 });

--- a/test/browser-tests/ok.html
+++ b/test/browser-tests/ok.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
 <head>
-<title>OK</title>
+<link rel='icon' href='data:;base64,iVBORw0KGgo='>
+  <title>OK</title>
 </head>
 <body>OK</body></html>


### PR DESCRIPTION
This is not backwards-compatible with the current version of the API; I have a separate update to w3c/Mobile-Checker to account for that that I'll submit once the npm version of this is available.