### PR TITLE
[WIP] Fix Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
+sudo: false
 language: node.js
+notifications:
+  irc:
+    channels:
+      - "irc.w3.org#sysreq"
+    skip_join: true
 install:
- - wget https://s3-us-west-1.amazonaws.com/lightbody-bmp/browsermob-proxy-2.0-beta-9-bin.zip
- - unzip browsermob-proxy-2.0-beta-9-bin.zip
- - browsermob-proxy-2.0-beta-9/bin/browsermob-proxy &
+ - wget https://github.com/lightbody/browsermob-proxy/releases/download/browsermob-proxy-2.1.0-beta-3/browsermob-proxy-2.1.0-beta-3-bin.zip
+ - unzip browsermob-proxy-2.1.0-beta-3-bin.zip
+ - browsermob-proxy-2.1.0-beta-3/bin/browsermob-proxy &
  - npm install
  - ./.travis-setup.sh
 script:


### PR DESCRIPTION
This PR:
* updates the URL of the latest [BrowserMob proxy](http://bmp.lightbody.net/) ZIP (necessary)
* migrates the Travis config to [container-based infrastructure](https://docs.travis-ci.com/user/migrating-from-legacy) (good to have; legacy setup will be deprecated at some point in the future, I guess)
* sends notifications of build statuses to W3C IRC, `#sysreq` (nice addition, IMO).

Pending:
* Fix `.travis-setup.sh` to avoid `sudo` and [install custom software differently](https://docs.travis-ci.com/user/migrating-from-legacy#How-Do-I-Install-Custom-Software%3F).

@guibbs, @dontcallmedom: can you take a look at that script?