### PR TITLE
Fix build (in progress)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+bmp.log
 node_modules/
+browsermob-proxy-2.1.1-bin.zip
+browsermob-proxy-2.1.1/
+google-chrome-stable_current_amd64.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: false
+sudo: required
+dist: trusty
 language: node.js
 notifications:
   irc:
@@ -6,9 +7,9 @@ notifications:
       - "irc.w3.org#sysreq"
     skip_join: true
 install:
- - wget https://github.com/lightbody/browsermob-proxy/releases/download/browsermob-proxy-2.1.0-beta-3/browsermob-proxy-2.1.0-beta-3-bin.zip
- - unzip browsermob-proxy-2.1.0-beta-3-bin.zip
- - browsermob-proxy-2.1.0-beta-3/bin/browsermob-proxy &
+ - wget https://github.com/lightbody/browsermob-proxy/releases/download/browsermob-proxy-2.1.1/browsermob-proxy-2.1.1-bin.zip
+ - unzip browsermob-proxy-2.1.1-bin.zip
+ - browsermob-proxy-2.1.1/bin/browsermob-proxy &
  - npm install
  - ./.travis-setup.sh
 script:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "mobile-web-browser-emulator",
     "description": "Emulation of a Chrome-based browser on a mobile device for Node.js",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "license": "MIT",
     "repository": {
         "type": "git",
@@ -11,24 +11,24 @@
         "url": "https://github.com/w3c/mobile-web-browser-emulator/issues"
     },
     "dependencies": {
-        "browsermob-proxy":"1.0.6",
-        "chromedriver": "^2.15",
-        "easyimage": "1.0.2",
-        "headless": "0.2.1",
-        "intl": "^0.1.4",
-        "media-type": "0.1.0",
-        "metaviewport-parser": "^0.0.1",
-        "selenium-webdriver": "^2.46.1",
-        "node-uuid": "1.4.3",
-        "rimraf": "^2.4.0"
+        "browsermob-proxy": "1.0.9",
+        "chromedriver": "2.21.2",
+        "easyimage": "2.1.0",
+        "headless": "1.0.0",
+        "intl": "1.2.4",
+        "media-type": "0.3.0",
+        "metaviewport-parser": "0.0.1",
+        "node-uuid": "1.4.7",
+        "rimraf": "2.5.3",
+        "selenium-webdriver": "2.53.3"
     },
     "devDependencies": {
-        "expect.js": "^0.3.1",
-        "express": "4.4.1",
-        "mocha": "^2.2.5"
+        "expect.js": "0.3.1",
+        "express": "4.14.0",
+        "mocha": "2.5.3"
     },
     "scripts": {
-       "start": "node app.js",
-       "test": "mocha --timeout 10000 --globals ErrorHandler"
+        "start": "node app.js",
+        "test": "mocha --timeout 10000 --globals ErrorHandler"
     }
 }


### PR DESCRIPTION
@guibbs, @dontcallmedom: [the build in `master` crashes now](https://travis-ci.org/w3c/mobile-web-browser-emulator/builds/93880534) because Travis is not set up to use `sudo`. This fixes that.

This also updates all dependencies, including BrowserMob Proxy, and makes git ignore a bunch of local files.

The test suite now [gives a few errors](https://travis-ci.org/w3c/mobile-web-browser-emulator/builds/145774967). Any idea?

Once we fix this, I'd publish to npm. (Also, minor thing, but the one-line description on [`npmjs.com`](https://www.npmjs.com/~w3c) is wrong.)
